### PR TITLE
Fix tag translator and freelist interface

### DIFF
--- a/FreeList/Ifc.v
+++ b/FreeList/Ifc.v
@@ -2,7 +2,6 @@ Require Import Kami.AllNotations.
 Require Import StdLibKami.Fifo.Ifc.
 Section Freelist.
   Context {ty: Kind -> Type}.
-  Context {size: nat}.
   Context {k: Kind}.
   Record FreeList: Type :=
     {

--- a/TagTranslator.v
+++ b/TagTranslator.v
@@ -29,7 +29,9 @@ Section MemTagTranslator.
   Definition free := (FreeList.Ifc.free freelist).
 
   (* Action that allows us to make a request to physical memory *)
-  Context (memReq: reqK @# ty -> ActionT ty Bool).
+  Definition TagReq: Kind := STRUCT_TYPE { "tag" :: ServerTag;
+                                           "data" :: reqK}.
+  Context (memReq: TagReq @# ty -> ActionT ty Bool).
   
   (* Names of read/write names for the reg-file backing the
      associative array with which we will map server tags to client
@@ -52,7 +54,8 @@ Section MemTagTranslator.
   Definition clientReq (id: nat) (client: ClientData) (taggedReq: (ClientReq client) @# ty): ActionT ty Bool :=
     LETA mTag <- alloc;
     If (#mTag @% "valid") then (
-      LETA reqRet: Bool <- memReq (taggedReq @% "req": reqK @# ty);
+      LETA reqRet: Bool <- memReq (STRUCT { "tag" ::= (#mTag @% "data");
+                                           "data" ::= (taggedReq @% "req") }: TagReq @# ty);
       Ret #reqRet
       )
     else (


### PR DESCRIPTION
In particular, we now actually track the address desired from incoming requests and send the address back to the requester when fulfilling requests. 

Also removes a dead parameter from the freelist interface. @vmurali expressed a desire to parameterize the freelist interface by its size instead of the the kind `k` it's currently parameterized by, we should probably resolve this before merging.