### PR TITLE
Add FreeList spec; change the FreeList interface and make the necessary changes downstream

### DIFF
--- a/Arbiter/Impl.v
+++ b/Arbiter/Impl.v
@@ -53,7 +53,7 @@ Section ArbiterImpl.
                                      "data" ::= STRUCT { "id" ::= $(proj1_sig (Fin.to_nat id));
                                                          "tag" ::= (ZeroExtendTruncLsb _ (taggedReq @% "tag") : ClientTag @# ty) }
                                    }: WriteRq serverTagSz IdTag);
-        LETA _ <- alloc;
+        LETA _ <- alloc (#serverTag @% "data");
         Retv);
       Ret #reqOk )
      else Ret $$false as retVal;

--- a/FreeList/Ifc.v
+++ b/FreeList/Ifc.v
@@ -10,7 +10,7 @@ Section Freelist.
       length: nat;
       initialize: ActionT ty Void;
       nextToAlloc: ActionT ty (Maybe k);
-      alloc: ActionT ty (Maybe k);
+      alloc: k @# ty -> ActionT ty Bool;
       free: k @# ty -> ActionT ty Void;
     }.
 End Freelist.

--- a/FreeList/Spec.v
+++ b/FreeList/Spec.v
@@ -1,0 +1,45 @@
+Require Import Kami.AllNotations.
+Require Import StdLibKami.FreeList.Ifc.
+Section FreeListSpec.
+  Class FreeListParams := {
+                           TagSize: nat;
+                           ArrayRegName: string;
+                         }.
+
+  Section withParams.
+    Context (ty: Kind -> Type).
+    Context `{FreeListParams}.
+    
+    Definition len := Nat.pow 2 TagSize. (* length of the freelist *)
+    Definition CastTagSize := Nat.log2_up len.
+    Definition Tag := Bit CastTagSize.
+
+    Local Open Scope kami_expr.
+    Local Open Scope kami_action.
+
+    (* Initialization rule, which will fill the free list *)
+    Definition initialize: ActionT ty Void := Retv.
+
+    Definition nextToAlloc: ActionT ty (Maybe Tag) := 
+      Read freeArray: Array len Bool <- ArrayRegName;
+      Nondet random: Tag;
+      LET randomOk: Bool <- #freeArray@[#random];
+      LET res: Maybe Tag <- STRUCT { "valid" ::= !#randomOk;
+                                     "data" ::= #random };
+      Ret #res.
+  
+    Definition alloc (a: Tag @# ty): ActionT ty Bool := 
+      Read freeArray: Array len Bool <- ArrayRegName;
+      LET res: Bool <- #freeArray@[a];
+      Write ArrayRegName: Array len Bool <- #freeArray@[a <- IF #res then #res else $$true];
+      Ret !#res.
+  
+    Definition free (tag: Tag @# ty): ActionT ty Void :=
+      Read freeArray: Array len Bool <- ArrayRegName;                                                        
+      Write ArrayRegName: Array len Bool <- #freeArray@[tag <- $$false];
+      Retv.
+
+    Definition asyncFreeList: FreeList := Build_FreeList len initialize nextToAlloc
+                                                         alloc free.
+  End withParams.
+End FreeListSpec.


### PR DESCRIPTION
Closes #15. The FreeList spec was complicated by the fact that we would expect the `alloc` action to return the same tag as was returned by an adjacent previous call to the `nextToAlloc` action. Rather than adding complicated logic in the spec to make the `nextToAlloc` action "sticky", we opted to change the interface of FreeList to have `alloc` take a tag to mark as allocated, maybe failing if the tag is already allocated.